### PR TITLE
Update docker-compose

### DIFF
--- a/tdex/docker-compose.yml
+++ b/tdex/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       TDEX_CONNECT_PROTO: http
 
   dashboard:
-    image: ghcr.io/tdex-network/dashboard:v1.0.0-rc.0
+    image: ghcr.io/tdex-network/dashboard:v1.0.0-rc.1
     restart: on-failure
     ports:
       - 8080:8080

--- a/tdex/docker-compose.yml
+++ b/tdex/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8080
 
   oceand:
-    image: ghcr.io/vulpemventures/oceand:v0.1.17
+    image: ghcr.io/vulpemventures/oceand:v0.1.17@sha256:9a7e1b8df4d7907ad66e3475c5a5f357d73c49df96214c00eba121f2aea9a50d
     tty: true
     restart: on-failure
     stop_grace_period: 1m
@@ -21,7 +21,7 @@ services:
       OCEAN_UTXO_EXPIRY_DURATION_IN_SECONDS: 240
 
   tdexd:
-    image: ghcr.io/tdex-network/tdexd:v1.0.0
+    image: ghcr.io/tdex-network/tdexd:v1.0.0@sha256:6e6733015dceeab41db4780b5e99313d5bbbc5dc490800ee3b5a326a8b65b92d
     tty: true
     restart: on-failure
     depends_on:
@@ -44,7 +44,7 @@ services:
       TDEX_CONNECT_PROTO: http
 
   dashboard:
-    image: ghcr.io/tdex-network/dashboard:v1.0.0
+    image: ghcr.io/tdex-network/dashboard:v1.0.0@sha256:997f23a9d8d232afd7199f8d3fbcb7e6b49ff6fd1c52465eaf276cd64ed9dce3
     restart: on-failure
     ports:
       - 8080:8080

--- a/tdex/docker-compose.yml
+++ b/tdex/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       OCEAN_UTXO_EXPIRY_DURATION_IN_SECONDS: 240
 
   tdexd:
-    image: ghcr.io/tdex-network/tdexd:v1.0.0-rc.8
+    image: ghcr.io/tdex-network/tdexd:v1.0.0
     tty: true
     restart: on-failure
     depends_on:
@@ -44,7 +44,7 @@ services:
       TDEX_CONNECT_PROTO: http
 
   dashboard:
-    image: ghcr.io/tdex-network/dashboard:v1.0.0-rc.3
+    image: ghcr.io/tdex-network/dashboard:v1.0.0
     restart: on-failure
     ports:
       - 8080:8080

--- a/tdex/docker-compose.yml
+++ b/tdex/docker-compose.yml
@@ -6,10 +6,26 @@ services:
       APP_HOST: tdex_caddy_1
       APP_PORT: 8080
 
-  tdexd:
-    image: ghcr.io/tdex-network/tdexd:v0.9.1@sha256:5078897b9a505fc3dfac5b3d51537150941c075f5279ae81de1c6b1c21112544
+  oceand:
+    image: docker pull ghcr.io/vulpemventures/oceand:v0.1.17@sha256:9a7e1b8df4d7907ad66e3475c5a5f357d73c49df96214c00eba121f2aea9a50d
     tty: true
     restart: on-failure
+    stop_grace_period: 1m
+    volumes:
+      - ${APP_DATA_DIR}/ocean-data:/home/ocean/.oceand
+    environment:
+      OCEAN_LOG_LEVEL: 5
+      OCEAN_DB_TYPE: "badger"
+      OCEAN_NO_TLS: "true"
+      OCEAN_NO_PROFILER: "true"
+      OCEAN_UTXO_EXPIRY_DURATION_IN_SECONDS: 240
+
+  tdexd:
+    image: ghcr.io/tdex-network/tdexd:v1.0.0@sha256
+    tty: true
+    restart: on-failure
+    depends_on:
+      - oceand
     stop_grace_period: 1m
     volumes:
       - ${APP_DATA_DIR}/tdex-data:/home/tdex/.tdex-daemon
@@ -18,6 +34,7 @@ services:
       TDEX_OPERATOR_LISTENING_PORT: "${APP_TDEX_PORT}"
       TDEX_TRADE_LISTENING_PORT: "${APP_TDEX_PORT}"
       TDEX_NO_OPERATOR_TLS: "true"
+      TDEX_WALLET_ADDR: oceand:18000
       # these vars are used to generate the connect URL
       # we assume to always show the external endpoint
       # reachable remotely by other dashboards via Tor
@@ -25,7 +42,7 @@ services:
       TDEX_CONNECT_PROTO: http
 
   dashboard:
-    image: ghcr.io/tdex-network/dashboard:v0.1.55@sha256:dfa7cdb75117c97e671285fc9754a6cabafc7f74760c314e6625c33067509beb
+    image: ghcr.io/tdex-network/dashboard:v1.0.0@sha256
     restart: on-failure
     environment:
       USE_PROXY: "false"

--- a/tdex/docker-compose.yml
+++ b/tdex/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       TDEX_CONNECT_PROTO: http
 
   dashboard:
-    image: ghcr.io/tdex-network/dashboard:v1.0.0-rc.2
+    image: ghcr.io/tdex-network/dashboard:v1.0.0-rc.3
     restart: on-failure
     ports:
       - 8080:8080

--- a/tdex/docker-compose.yml
+++ b/tdex/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       OCEAN_UTXO_EXPIRY_DURATION_IN_SECONDS: 240
 
   tdexd:
-    image: ghcr.io/tdex-network/tdexd:v1.0.0@sha256
+    image: docker pull ghcr.io/tdex-network/tdexd:v1.0.0-rc.8@sha256:dab0b9928404c1fe65b1fec272affb53c75a11fe8f6b11a7e5962f3bf8882375
     tty: true
     restart: on-failure
     depends_on:
@@ -42,7 +42,7 @@ services:
       TDEX_CONNECT_PROTO: http
 
   dashboard:
-    image: ghcr.io/tdex-network/dashboard:v1.0.0@sha256
+    image: ghcr.io/tdex-network/dashboard:v1.0.0-rc.0
     restart: on-failure
     environment:
       USE_PROXY: "false"

--- a/tdex/docker-compose.yml
+++ b/tdex/docker-compose.yml
@@ -46,10 +46,12 @@ services:
   dashboard:
     image: ghcr.io/tdex-network/dashboard:v1.0.0-rc.0
     restart: on-failure
+    ports:
+      - 8080:8080
     environment:
       USE_PROXY: "false"
       IS_PACKAGED: "true"
-      TRADER_HIDDEN_SERVICE:  "${APP_TDEX_DAEMON_HIDDEN_SERVICE}"
+      TRADER_HIDDEN_SERVICE: "${APP_TDEX_DAEMON_HIDDEN_SERVICE}"
 
   caddy:
     image: caddy:2.6.4-alpine@sha256:4dfec6c3b22c36b63ea4a3633c7cdbdaa9926d1324c27db2b0e2b70ef9cd105a

--- a/tdex/docker-compose.yml
+++ b/tdex/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       TDEX_CONNECT_PROTO: http
 
   dashboard:
-    image: ghcr.io/tdex-network/dashboard:v1.0.0-rc.1
+    image: ghcr.io/tdex-network/dashboard:v1.0.0-rc.2
     restart: on-failure
     ports:
       - 8080:8080

--- a/tdex/docker-compose.yml
+++ b/tdex/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       APP_PORT: 8080
 
   oceand:
-    image: docker pull ghcr.io/vulpemventures/oceand:v0.1.17@sha256:9a7e1b8df4d7907ad66e3475c5a5f357d73c49df96214c00eba121f2aea9a50d
+    image: ghcr.io/vulpemventures/oceand:v0.1.17
     tty: true
     restart: on-failure
     stop_grace_period: 1m
@@ -21,7 +21,7 @@ services:
       OCEAN_UTXO_EXPIRY_DURATION_IN_SECONDS: 240
 
   tdexd:
-    image: docker pull ghcr.io/tdex-network/tdexd:v1.0.0-rc.8@sha256:dab0b9928404c1fe65b1fec272affb53c75a11fe8f6b11a7e5962f3bf8882375
+    image: ghcr.io/tdex-network/tdexd:v1.0.0-rc.8
     tty: true
     restart: on-failure
     depends_on:
@@ -29,6 +29,8 @@ services:
     stop_grace_period: 1m
     volumes:
       - ${APP_DATA_DIR}/tdex-data:/home/tdex/.tdex-daemon
+    ports:
+     - ${APP_TDEX_PORT}:${APP_TDEX_PORT}
     environment:
       TDEX_LOG_LEVEL: 5
       TDEX_OPERATOR_LISTENING_PORT: "${APP_TDEX_PORT}"

--- a/tdex/hooks/pre-start
+++ b/tdex/hooks/pre-start
@@ -6,8 +6,9 @@ if [[ -f "${HIDDEN_SERVICE_FILE}" ]]; then
 	exit
 fi
 
-"${UMBREL_ROOT}/scripts/app" compose "${APP_ID}" up --detach tdexd
 "${UMBREL_ROOT}/scripts/app" compose "${APP_ID}" up --detach tor
+"${UMBREL_ROOT}/scripts/app" compose "${APP_ID}" up --detach oceand
+"${UMBREL_ROOT}/scripts/app" compose "${APP_ID}" up --detach tdexd
 
 echo "App: ${APP_ID} - Generating Tor Hidden Service..."
 for attempt in $(seq 1 100); do

--- a/tdex/umbrel-app.yml
+++ b/tdex/umbrel-app.yml
@@ -2,7 +2,7 @@ manifestVersion: 1.1
 id: tdex
 category: bitcoin
 name: TDEX Provider
-version: "0.9.1"
+version: "1.0.0"
 tagline: Provide liquidity on the TDEX Network, an open protocol to trade Liquid Network assets.
 description: >-
   A liquidity provider holds Liquid reserves of both a BASE_ASSET-QUOTE_ASSET in his non-custodial Liquid hot-wallet,


### PR DESCRIPTION
This updates the compose file of umbrel in order to use the latest versions of the TDEX v2 protocol services.

This is currently a WIP, we still need to tag `v1.0.0` for both the daemon and the dashboard.

@tiero please review. Is it enough to use docker-compose locally to test this?

I also need to know if we use images for _linux/amd64_ or _linux/arm64_ platform.